### PR TITLE
공통 버튼 컴포넌트 구현

### DIFF
--- a/gillajabi/src/components/Button.jsx
+++ b/gillajabi/src/components/Button.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import '../styles/components/Button.css'
+
+const Button = (props) => {
+
+  const { children, type, onClick, disabled } = props;
+
+  const btnTypeList = ['Large_Orange','Large_White'];
+  const btnType = btnTypeList.includes(type) ? type : 'default'
+
+  return (
+    <button className = {btnType} onClick = {onClick} disabled = {disabled}>
+      {children}
+    </button>
+  );
+};
+
+Button.defaultProps = {
+  type : "default",
+  onClick : () => {},
+  disabled : false
+}
+
+export default Button;

--- a/gillajabi/src/styles/components/Button.css
+++ b/gillajabi/src/styles/components/Button.css
@@ -1,0 +1,12 @@
+button{
+  border : none;
+  text-align: center;
+}
+.Large_Orange{
+  background-color: #ff911b;
+  color : #ffffff;
+}
+.Large_White{
+  background-color: #ffffff;
+  color : #ff911b;
+}


### PR DESCRIPTION
### 📃 작업 내용
- 공통 버튼 컴포넌트 추가
- props로 children, type, onClick, disalbed를 받고, 기본 props 값으로 type : default, onClick : ( ) => { }, disabled : false를 부여
- 타입 예시로 Large_Orange, Large_White를 추가, 로그인 페이지 개발 과정에서 스타일 수정 예정

### 😎 PR 타입
 - [x] 기능 추가
 - [ ] 기능 삭제
 - [ ] 버그 수정
 - [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
 
### 🌿 반영 브랜치
- ledraco/button -> develop

### ❕ 참고 사항
- 버튼 타입 추가 시 Button.jsx의 btnTypeList에 타입 추가 후 Button.css에 스타일 추가할 것
