### PR TITLE
로그인 페이지 구현

### DIFF
--- a/gillajabi/.gitignore
+++ b/gillajabi/.gitignore
@@ -21,3 +21,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+.env.development

--- a/gillajabi/package-lock.json
+++ b/gillajabi/package-lock.json
@@ -11,6 +11,7 @@
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
+        "axios": "^1.4.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.14.2",
@@ -5299,6 +5300,29 @@
       "integrity": "sha512-zIURGIS1E1Q4pcrMjp+nnEh+16G56eG/MUllJH8yEvw7asDo7Ac9uhC9KIH5jzpITueEZolfYglnCGIuSBz39g==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
+      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/axobject-query": {
@@ -14299,6 +14323,11 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
     "node_modules/psl": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
@@ -21296,6 +21325,28 @@
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.7.2.tgz",
       "integrity": "sha512-zIURGIS1E1Q4pcrMjp+nnEh+16G56eG/MUllJH8yEvw7asDo7Ac9uhC9KIH5jzpITueEZolfYglnCGIuSBz39g=="
     },
+    "axios": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
+      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
+      "requires": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
     "axobject-query": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-3.2.1.tgz",
@@ -27618,6 +27669,11 @@
           "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
         }
       }
+    },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "psl": {
       "version": "1.9.0",

--- a/gillajabi/package-lock.json
+++ b/gillajabi/package-lock.json
@@ -16,7 +16,8 @@
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.14.2",
         "react-scripts": "5.0.1",
-        "web-vitals": "^2.1.4"
+        "web-vitals": "^2.1.4",
+        "zustand": "^4.4.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -16639,6 +16640,14 @@
         "requires-port": "^1.0.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -17634,6 +17643,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.4.0.tgz",
+      "integrity": "sha512-2dq6wq4dSxbiPTamGar0NlIG/av0wpyWZJGeQYtUOLegIUvhM2Bf86ekPlmgpUtS5uR7HyetSiktYrGsdsyZgQ==",
+      "dependencies": {
+        "use-sync-external-store": "1.2.0"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     }
   },
@@ -29358,6 +29394,12 @@
         "requires-port": "^1.0.0"
       }
     },
+    "use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "requires": {}
+    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -30130,6 +30172,14 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
+    },
+    "zustand": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.4.0.tgz",
+      "integrity": "sha512-2dq6wq4dSxbiPTamGar0NlIG/av0wpyWZJGeQYtUOLegIUvhM2Bf86ekPlmgpUtS5uR7HyetSiktYrGsdsyZgQ==",
+      "requires": {
+        "use-sync-external-store": "1.2.0"
+      }
     }
   }
 }

--- a/gillajabi/package.json
+++ b/gillajabi/package.json
@@ -6,6 +6,7 @@
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
+    "axios": "^1.4.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.14.2",

--- a/gillajabi/package.json
+++ b/gillajabi/package.json
@@ -11,7 +11,8 @@
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.14.2",
     "react-scripts": "5.0.1",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "zustand": "^4.4.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/gillajabi/src/App.js
+++ b/gillajabi/src/App.js
@@ -1,10 +1,12 @@
 import React, { useState, useEffect } from 'react'
 import { BrowserRouter, Route, Routes } from 'react-router-dom'
 import { Main, Splash, Signup, Login, Mypage, Category} from './pages'
+import { useUserStore } from './stores/userStore';
 import './App.css'
 
 function App() {
   const [showSplash, setShowSplash] = useState(true);
+  const { getUserInfo } = useUserStore();
 
   useEffect(() => {
     const visited = sessionStorage.getItem('visited');
@@ -20,6 +22,11 @@ function App() {
       const timer = setTimeout(hideSplashScreen, 4000);
 
       return () => clearTimeout(timer);
+    }
+
+    const token = localStorage.getItem('accessToken');
+    if(token){
+      getUserInfo(token);
     }
   }, []);
 

--- a/gillajabi/src/authApi.jsx
+++ b/gillajabi/src/authApi.jsx
@@ -1,0 +1,42 @@
+import axios from 'axios';
+
+const authApi = axios.create();
+
+// refreshToken을 사용하여 accessToken을 갱신하는 함수
+async function refreshAccessToken() {
+  try {
+    const response = await axios.get(`${process.env.REACT_APP_API}/api/users/token/refresh/`);
+    const newAccessToken = response.data.access;
+    return newAccessToken;
+  } catch (error) {
+    throw new Error('새로운 accessToken을 가져오는데 실패하였습니다.');
+  }
+}
+
+// Axios 인터셉터를 활용하여 401 (Unauthorized) 에러 시 accessToken을 갱신합니다.
+authApi.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const originalRequest = error.config;
+
+    if (error.response.status === 401 && !originalRequest._retry) {
+      originalRequest._retry = true;
+      try {
+        const newAccessToken = await refreshAccessToken();
+        if (newAccessToken) {
+          // 새로운 accessToken을 헤더에 추가하여 재요청
+          localStorage.setItem('accessToken', newAccessToken);
+          originalRequest.headers['Authorization'] = `Bearer ${newAccessToken}`;
+          return axios(originalRequest);
+        }
+      } catch (error) {
+        console.error('accessToken 갱신에 실패하였습니다:', error.message);
+        localStorage.removeItem('accessToken');
+        throw new Error('새로운 accessToken을 가져오는데 실패하였습니다.');
+      }
+    }
+    return Promise.reject(error);
+  }
+);
+
+export default authApi;

--- a/gillajabi/src/pages/Login/Login.jsx
+++ b/gillajabi/src/pages/Login/Login.jsx
@@ -1,11 +1,14 @@
 import React, { useState } from 'react';
 import axios from 'axios'
 import { useNavigate } from 'react-router-dom';
+import { useUserStore } from '../../stores/userStore';
 import LoginformButton from './components/LoginformButton';
 import LoginformInput from './components/LoginformInput';
 import '../../styles/pages/Login.css';
 
 const Login = () => {
+
+  const {setUser} = useUserStore();
   const [formData, setFormData] = useState({
     user_id : '',
     password : '',
@@ -37,6 +40,7 @@ const Login = () => {
   
       if (response.status >= 200 && response.status < 300) {
         const token = response.data.token;
+        setUser(response.data.user);
         localStorage.setItem('token', token);
         navigate('/');
       } else {

--- a/gillajabi/src/pages/Login/Login.jsx
+++ b/gillajabi/src/pages/Login/Login.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import LoginformButton from './components/LoginformButton';
 import LoginformInput from './components/LoginformInput';
 import '../../styles/pages/Login.css';
 
@@ -8,6 +9,7 @@ const Login = () => {
       <h2>길라잡이</h2>
       <form className='login-form'>
         <LoginformInput/>
+        <LoginformButton/>
       </form>
     </div>
   );

--- a/gillajabi/src/pages/Login/Login.jsx
+++ b/gillajabi/src/pages/Login/Login.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import LoginformInput from './components/LoginformInput';
+import '../../styles/pages/Login.css';
 
 const Login = () => {
   return (

--- a/gillajabi/src/pages/Login/Login.jsx
+++ b/gillajabi/src/pages/Login/Login.jsx
@@ -1,14 +1,59 @@
-import React from 'react';
+import React, { useState } from 'react';
+import axios from 'axios'
+import { useNavigate } from 'react-router-dom';
 import LoginformButton from './components/LoginformButton';
 import LoginformInput from './components/LoginformInput';
 import '../../styles/pages/Login.css';
 
 const Login = () => {
+  const [formData, setFormData] = useState({
+    user_id : '',
+    password : '',
+  });
+
+  const navigate = useNavigate();
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setFormData((prevData) => ({
+      ...prevData,
+      [name]: value,
+    }));
+  };
+  
+  const handleLogin = async (e) => {
+    e.preventDefault();
+    
+    if (!formData.user_id || !formData.password) {
+      alert("아이디와 비밀번호를 입력해주세요.");
+      return;
+    }
+
+    try {
+      const response = await axios.post(`${process.env.REACT_APP_API}/api/users/login/`, {
+        user_id: formData.user_id,
+        password: formData.password,
+      });
+  
+      if (response.status >= 200 && response.status < 300) {
+        const token = response.data.token;
+        localStorage.setItem('token', token);
+        navigate('/');
+      } else {
+        if (response.status >= 400) throw new Error(`클라이언트 오류: 응답 상태 코드 ${response.status}`);
+        if (response.status >= 500) throw new Error(`서버 오류: 응답 상태 코드 ${response.status}`);
+      }
+    } catch (error) {
+      alert('로그인에 실패했습니다. 다시 시도해주세요.');
+      console.error(error.message);
+    }
+  };
+
   return (
     <div className='login'>
       <h2>길라잡이</h2>
-      <form className='login-form'>
-        <LoginformInput/>
+      <form className='login-form' onSubmit={handleLogin}>
+        <LoginformInput formData={formData} handleChange={handleChange} />
         <LoginformButton/>
       </form>
     </div>

--- a/gillajabi/src/pages/Login/Login.jsx
+++ b/gillajabi/src/pages/Login/Login.jsx
@@ -39,9 +39,9 @@ const Login = () => {
       });
   
       if (response.status >= 200 && response.status < 300) {
-        const token = response.data.token;
+        const token = response.data.access_token;
         setUser(response.data.user);
-        localStorage.setItem('token', token);
+        localStorage.setItem('accessToken', token);
         navigate('/');
       } else {
         if (response.status >= 400) throw new Error(`클라이언트 오류: 응답 상태 코드 ${response.status}`);

--- a/gillajabi/src/pages/Login/Login.jsx
+++ b/gillajabi/src/pages/Login/Login.jsx
@@ -1,9 +1,13 @@
 import React from 'react';
+import LoginformInput from './components/LoginformInput';
 
 const Login = () => {
   return (
-    <div>
-      로그인 페이지입니다.
+    <div className='login'>
+      <h2>길라잡이</h2>
+      <form className='login-form'>
+        <LoginformInput/>
+      </form>
     </div>
   );
 };

--- a/gillajabi/src/pages/Login/components/LoginformButton.jsx
+++ b/gillajabi/src/pages/Login/components/LoginformButton.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import Button from '../../../components/Button';
+
+const LoginformButton = () => {
+  return (
+    <>
+      <div className='login-optionbtn'>
+        <Button>
+          회원가입
+        </Button>
+        <div className='login-vline'></div>
+        <Button>
+          비밀번호 찾기
+        </Button>
+      </div>
+      <div className='login-startbtn'>
+        <Button styleType = {'Large_Orange'}>
+          시작하기
+        </Button>
+        <Button styleType = {'Large_White'}> 
+          건너뛰기
+        </Button>
+      </div>
+    </>
+  );
+};
+
+export default LoginformButton;

--- a/gillajabi/src/pages/Login/components/LoginformButton.jsx
+++ b/gillajabi/src/pages/Login/components/LoginformButton.jsx
@@ -1,23 +1,34 @@
 import React from 'react';
 import Button from '../../../components/Button';
+import { useNavigate } from 'react-router-dom';
 
 const LoginformButton = () => {
+
+  const navigate = useNavigate();
+
   return (
     <>
       <div className='login-optionbtn'>
-        <Button>
+        <Button type='button' onClick={() => navigate('/signup')}>
           회원가입
         </Button>
         <div className='login-vline'></div>
-        <Button>
+        <Button type='button'>
           비밀번호 찾기
         </Button>
       </div>
       <div className='login-startbtn'>
-        <Button styleType = {'Large_Orange'}>
+        <Button 
+          type='submit'
+          styleType = {'Large_Orange'}
+        >
           시작하기
         </Button>
-        <Button styleType = {'Large_White'}> 
+        <Button 
+          type='button'
+          styleType = {'Large_White'}
+          onClick={() => navigate('/')}
+        > 
           건너뛰기
         </Button>
       </div>

--- a/gillajabi/src/pages/Login/components/LoginformInput.jsx
+++ b/gillajabi/src/pages/Login/components/LoginformInput.jsx
@@ -1,33 +1,30 @@
 import React, { useState } from 'react';
 
-const LoginformInput = () => {
+const LoginformInput = ({ formData, handleChange }) => {
 
   const [showPassword, setShowPassword] = useState(false);
-  const [password, setPassword] = useState('');
 
   const handlePasswordToggle = () => {
     setShowPassword((prevState) => !prevState);
   };
 
-  const handlePasswordChange = (event) => {
-    setPassword(event.target.value);
-  };
-
   return (
     <div className='login-form-input'>
-      <label htmlFor='id'>아이디</label>
+      <label htmlFor='user_id'>아이디</label>
       <input
         type="text"
-        name="id"
+        name="user_id"
         placeholder="아이디"
+        value={formData.user_id}
+        onChange={handleChange}
       />
       <label htmlFor='password'>비밀번호</label>
       <input
         type={showPassword ? "text" : "password"}
         name="password"
         placeholder="비밀번호"
-        value={password}
-        onChange={handlePasswordChange}
+        value={formData.password}
+        onChange={handleChange}
       />
       <label htmlFor="showPassword">
         <input

--- a/gillajabi/src/pages/Login/components/LoginformInput.jsx
+++ b/gillajabi/src/pages/Login/components/LoginformInput.jsx
@@ -1,0 +1,45 @@
+import React, { useState } from 'react';
+
+const LoginformInput = () => {
+
+  const [showPassword, setShowPassword] = useState(false);
+  const [password, setPassword] = useState('');
+
+  const handlePasswordToggle = () => {
+    setShowPassword((prevState) => !prevState);
+  };
+
+  const handlePasswordChange = (event) => {
+    setPassword(event.target.value);
+  };
+
+  return (
+    <div className='login-form-input'>
+      <label htmlFor='id'>아이디</label>
+      <input
+        type="text"
+        name="id"
+        placeholder="아이디"
+      />
+      <label htmlFor='password'>비밀번호</label>
+      <input
+        type={showPassword ? "text" : "password"}
+        name="password"
+        placeholder="비밀번호"
+        value={password}
+        onChange={handlePasswordChange}
+      />
+      <label htmlFor="showPassword">
+        <input
+          type="checkbox"
+          id="showPassword"
+          checked={showPassword}
+          onChange={handlePasswordToggle}
+        />
+        {showPassword ? "비밀번호 숨기기" : "비밀번호 표시"}
+      </label>
+    </div>
+  );
+};
+
+export default LoginformInput;

--- a/gillajabi/src/stores/userStore.js
+++ b/gillajabi/src/stores/userStore.js
@@ -1,0 +1,18 @@
+import { create } from 'zustand';
+
+export const useUserStore = create((set, get) => ({
+  user: null,
+  /**
+  * 사용자 데이터를 설정합니다.
+  * @param {Object} userData - 사용자 데이터
+  */
+  setUser: (userData) => set({ user: userData }),
+  
+  /**
+   * 사용자 로그아웃을 처리합니다.
+  */
+  logout: () => {
+    localStorage.removeItem('token');
+    set({ user: null });
+  },
+}));

--- a/gillajabi/src/stores/userStore.js
+++ b/gillajabi/src/stores/userStore.js
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import authApi from '../authApi';
 
 export const useUserStore = create((set, get) => ({
   user: null,
@@ -12,7 +13,30 @@ export const useUserStore = create((set, get) => ({
    * 사용자 로그아웃을 처리합니다.
   */
   logout: () => {
-    localStorage.removeItem('token');
+    localStorage.removeItem('accessToken');
     set({ user: null });
+  },
+
+  /**
+ * 토큰 유효성을 확인하고 사용자 정보를 가져오는 함수.
+ * @async
+ * @param {string} token - 서버에 요청할 때 사용할 액세스 토큰
+ * @throws {Error} - 요청이 실패하거나 오류가 발생한 경우 해당 오류를 던집니다.
+ * @returns {Promise<void>} - 사용자 정보를 가져오고, 상태 관리 스토어에 사용자 데이터를 설정합니다.
+ */
+  getUserInfo: async (token) => {
+    try {
+      const response = await authApi.get(`${process.env.REACT_APP_API}/api/users/token/validate/`, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+      if ( response.status >= 200 && response.status < 300 && response.data.isvalid) {
+        const user = response.data.user;
+        get().setUser(user);
+      }
+    } catch (error) {
+      console.error(error.message);
+    }
   },
 }));

--- a/gillajabi/src/styles/components/Button.css
+++ b/gillajabi/src/styles/components/Button.css
@@ -1,12 +1,33 @@
 button{
   border : none;
   text-align: center;
+  white-space: nowrap;
+}
+.default{
+  background-color: #F2F3F6;
+  color : black;
+  font-weight: bold;
+  width : 40%;
+  border-radius: 8px;
+  font-size: 0.8em;
+  padding : 0.8em;
 }
 .Large_Orange{
   background-color: #ff911b;
   color : #ffffff;
+  width : 90%;
+  font-weight: bold;
+  border-radius: 8px;
+  font-size: 1em;
+  padding : 0.6em;
 }
 .Large_White{
   background-color: #ffffff;
   color : #ff911b;
+  border : 2px solid #ff911b;
+  font-weight: bold;
+  width : 90%;
+  font-size: 1em;
+  border-radius: 8px;
+  padding : 0.6em;
 }

--- a/gillajabi/src/styles/pages/Login.css
+++ b/gillajabi/src/styles/pages/Login.css
@@ -1,0 +1,75 @@
+/* 로그인 페이지 */
+.login {
+  box-sizing: border-box;
+  height: 100%;
+  padding: 10%;
+  display: flex;
+  flex-direction: column;
+
+  @media (max-width: 320px) {
+    font-size: 0.8rem;
+  }
+}
+.login h2 {
+  text-align: center;
+  font-size: 2.5em;
+  color: #FF911B;
+  margin-bottom: 10%;
+}
+
+/* 로그인 폼 */
+.login-form {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  min-height: 60%;
+  overflow-y: auto;
+  border : 2px solid black;
+}
+
+/* LoginformInput 컴포넌트 */
+.login-form-input {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+
+.login-form-input label {
+  font-size: 1.1em;
+  font-weight: bold;
+  color: #3F3E3E;
+  margin-bottom: 3%;
+}
+
+.login-form-input input {
+  border: none;
+  background-color: #EDEEF0;
+  color: #999999;
+  border-radius: 8px;
+  padding: 1.1em;
+  font-weight: bold;
+}
+
+.login-form-input label:nth-last-child(1) {
+  font-size: 1em;
+  margin-top: 2%;
+}
+
+/* 비밀번호 보기/숨기기 체크박스 스타일 */
+.login-form-input input[type="checkbox"] {
+  /* 체크박스의 색상 변경 */
+  accent-color: #FF911B;
+  /* 체크박스가 왼쪽에 위치하도록 설정 */
+  margin-right: 0.5em;
+}
+
+.login-form-input input:first-of-type {
+  margin-bottom: 5%;
+}
+
+.login-form-input input:focus {
+  outline: none;
+}

--- a/gillajabi/src/styles/pages/Login.css
+++ b/gillajabi/src/styles/pages/Login.css
@@ -25,8 +25,6 @@
   justify-content: center;
   align-items: center;
   min-height: 60%;
-  overflow-y: auto;
-  border : 2px solid black;
 }
 
 /* LoginformInput 컴포넌트 */
@@ -72,4 +70,28 @@
 
 .login-form-input input:focus {
   outline: none;
+}
+
+/* LoginformButton 컴포넌트 */
+.login-optionbtn {
+  display: flex;
+  justify-content: space-evenly;
+  width : 100%;
+  margin-bottom: 10%;
+}
+
+.login-vline {
+  border-left: 2px solid #828896;
+  height: 100%;
+}
+
+.login-startbtn {
+  display: flex;
+  flex-direction: column;
+  width : 100%;
+  align-items: center;
+}
+
+.login-startbtn button:nth-child(1) {
+  margin-bottom: 3%;
 }


### PR DESCRIPTION
### 📃 작업 내용

- 가입된 아이디와 비밀번호를 입력하고 건너뛰기 버튼을 누르면 로그인
- 하단 체크박스를 통해 비밀번호 표시 및 숨기기
- 건너뛰기 시 로그인을 건너뛰고 메인 페이지로 이동
- 회원가입 버튼을 누를 시 회원 가입 페이지로 이동
- zustand 상태 관리 라이브러리 및 axios 라이브러리 추가
- 새로고침 시 로그인 유지를 위해 accessToken을 통해 사용자 정보를 조회
- 토큰 유효성 확인 및 사용자 정보를 가져와 상태 관리 스토어에 사용자
  데이터를 설정하는 getUserInfo 구현
- axios 인터셉터를 통해 access token이 만료되어 401 (Unauthorized) 에러
  시 refresh token을 통해 갱신하며 이전 요청을 재수행하는 authApi 구현

### 😎 PR 타입

- [x]  기능 추가
- [ ]  기능 삭제
- [ ]  버그 수정
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트

### 🌿 반영 브랜치

- ledraco/login -> develop

### ❕ 참고 사항
- 로그인 페이지 하단에 0Atuh 로그인 버튼이 들어갈 예정
- 현재 백엔드에서 갱신된 access token의 처리 이슈가 있음
- 비밀번호 찾기 기능은 이후 추가 예정

### 👀 미리보기
![image](https://github.com/Team-Columbus/Gillajabi-FE/assets/98178673/fc15bfb8-5519-48e9-8b39-de4df1af0435)
