### PR TITLE
공통 Navbar 컴포넌트 및 공통 Option 컴포넌트 구현

### DIFF
--- a/gillajabi/package-lock.json
+++ b/gillajabi/package-lock.json
@@ -8,6 +8,10 @@
       "name": "gillajabi",
       "version": "0.1.0",
       "dependencies": {
+        "@fortawesome/fontawesome-svg-core": "^6.4.2",
+        "@fortawesome/free-regular-svg-icons": "^6.4.2",
+        "@fortawesome/free-solid-svg-icons": "^6.4.2",
+        "@fortawesome/react-fontawesome": "^0.2.0",
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
@@ -2378,6 +2382,63 @@
       "integrity": "sha512-a8TLtmPi8xzPkCbp/OGFUo5yhRkHM2Ko9kOWP4znJr0WAhWyThaw3PnwX4vOTWOAMsV2uRt32PPDcEz63esSaA==",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.4.2.tgz",
+      "integrity": "sha512-1DgP7f+XQIJbLFCTX1V2QnxVmpLdKdzzo2k8EmvDOePfchaIGQ9eCHj2up3/jNEbZuBqel5OxiaOJf37TWauRA==",
+      "hasInstallScript": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-svg-core": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.4.2.tgz",
+      "integrity": "sha512-gjYDSKv3TrM2sLTOKBc5rH9ckje8Wrwgx1CxAPbN5N3Fm4prfi7NsJVWd1jklp7i5uSCVwhZS5qlhMXqLrpAIg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.4.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-regular-svg-icons": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.4.2.tgz",
+      "integrity": "sha512-0+sIUWnkgTVVXVAPQmW4vxb9ZTHv0WstOa3rBx9iPxrrrDH6bNLsDYuwXF9b6fGm+iR7DKQvQshUH/FJm3ed9Q==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.4.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-solid-svg-icons": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.4.2.tgz",
+      "integrity": "sha512-sYwXurXUEQS32fZz9hVCUUv/xu49PEJEyUOsA51l6PU/qVgfbTb2glsTEaJngVVT8VqBATRIdh7XVgV1JF1LkA==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.4.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/react-fontawesome": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.0.tgz",
+      "integrity": "sha512-uHg75Rb/XORTtVt7OS9WoK8uM276Ufi7gCzshVWkUJbHhh3svsUUeqXerrM96Wm7fRiDzfKRwSoahhMIkGAYHw==",
+      "dependencies": {
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "@fortawesome/fontawesome-svg-core": "~1 || ~6",
+        "react": ">=16.3"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -16491,16 +16552,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=4.2.0"
       }
     },
     "node_modules/unbox-primitive": {
@@ -19187,6 +19248,43 @@
       "version": "8.46.0",
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.46.0.tgz",
       "integrity": "sha512-a8TLtmPi8xzPkCbp/OGFUo5yhRkHM2Ko9kOWP4znJr0WAhWyThaw3PnwX4vOTWOAMsV2uRt32PPDcEz63esSaA=="
+    },
+    "@fortawesome/fontawesome-common-types": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.4.2.tgz",
+      "integrity": "sha512-1DgP7f+XQIJbLFCTX1V2QnxVmpLdKdzzo2k8EmvDOePfchaIGQ9eCHj2up3/jNEbZuBqel5OxiaOJf37TWauRA=="
+    },
+    "@fortawesome/fontawesome-svg-core": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.4.2.tgz",
+      "integrity": "sha512-gjYDSKv3TrM2sLTOKBc5rH9ckje8Wrwgx1CxAPbN5N3Fm4prfi7NsJVWd1jklp7i5uSCVwhZS5qlhMXqLrpAIg==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "6.4.2"
+      }
+    },
+    "@fortawesome/free-regular-svg-icons": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.4.2.tgz",
+      "integrity": "sha512-0+sIUWnkgTVVXVAPQmW4vxb9ZTHv0WstOa3rBx9iPxrrrDH6bNLsDYuwXF9b6fGm+iR7DKQvQshUH/FJm3ed9Q==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "6.4.2"
+      }
+    },
+    "@fortawesome/free-solid-svg-icons": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.4.2.tgz",
+      "integrity": "sha512-sYwXurXUEQS32fZz9hVCUUv/xu49PEJEyUOsA51l6PU/qVgfbTb2glsTEaJngVVT8VqBATRIdh7XVgV1JF1LkA==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "6.4.2"
+      }
+    },
+    "@fortawesome/react-fontawesome": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.0.tgz",
+      "integrity": "sha512-uHg75Rb/XORTtVt7OS9WoK8uM276Ufi7gCzshVWkUJbHhh3svsUUeqXerrM96Wm7fRiDzfKRwSoahhMIkGAYHw==",
+      "requires": {
+        "prop-types": "^15.8.1"
+      }
     },
     "@humanwhocodes/config-array": {
       "version": "0.11.10",
@@ -29300,9 +29398,9 @@
       }
     },
     "typescript": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "peer": true
     },
     "unbox-primitive": {

--- a/gillajabi/package.json
+++ b/gillajabi/package.json
@@ -3,6 +3,10 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "^6.4.2",
+    "@fortawesome/free-regular-svg-icons": "^6.4.2",
+    "@fortawesome/free-solid-svg-icons": "^6.4.2",
+    "@fortawesome/react-fontawesome": "^0.2.0",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",

--- a/gillajabi/src/components/Navbar.jsx
+++ b/gillajabi/src/components/Navbar.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import '../styles/components/Navbar.css'
+import { faUser, faHouse, faDownload, faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons';
+import { faCircleQuestion, faCircleLeft } from '@fortawesome/free-regular-svg-icons';
+import Option from './Option.jsx';
+
+/**
+ * Navbar 컴포넌트는 헤더 바를 구성하는 React 컴포넌트입니다.
+ * @param {number} props.loginStatus - 로그인 상태를 나타내는 숫자 값 (0: 비로그인 상태, 1: 로그인 상태).
+ * @param {number} props.pageStatus - 페이지 상태를 나타내는 숫자 값 (0: 처음화면, 1: 다른화면).
+ * @param {number} props.subscribeStatus - 구독 상태를 나타내는 숫자 값 (0: 구독하지 않음, 1: 구독 중).
+ * @returns {JSX.Element} 헤더 바를 나타내는 JSX 요소
+ */
+
+const Navbar = (props) => {
+  const loginText = props.loginStatus === 1 ? '내 정보' : '로그인 하기';
+
+  return (
+    <div className='navbar'>
+      {props.pageStatus === 1 ? (
+        <Option iconName={faUser} Text={loginText} />
+      ) : (
+        <Option iconName={faCircleLeft} Text={'이전화면'} />
+      )}
+      {props.subscribeStatus === 1 ? (
+        <Option iconName={faCircleQuestion} Text={'오늘의 문제'} />
+      ) : null}
+
+      {props.pageStatus === 0 ? (
+        <Option iconName={faHouse} Text={'처음화면'} />
+      ) : null}
+
+      {props.subscribeStatus === 1 ? (
+        <Option iconName={faDownload} Text={'불러오기'} />
+      ) : null}
+
+      <Option iconName={faMagnifyingGlass} Text={'돋보기'} />
+    </div>
+  );
+};
+
+export default Navbar;

--- a/gillajabi/src/components/Option.jsx
+++ b/gillajabi/src/components/Option.jsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import '../styles/components/Option.css'
+
+/**
+ * Option 컴포넌트는 아이콘과 텍스트로 구성된 옵션을 렌더링하는 React 컴포넌트입니다.
+ * @param {string} [props.className] - 옵션 컨테이너의 클래스 이름을 지정합니다. (클래스 이름 : 배경색 설정)
+ * @param {object} props.iconName - FontAwesome 아이콘 객체를 나타내는 변수입니다.
+ * @param {string} props.Text - 옵션에 대한 텍스트 내용입니다.
+ * @returns {JSX.Element} 아이콘과 텍스트로 구성된 옵션을 나타내는 JSX 요소
+ */
+
+const Option = (props) => {
+  const optionName = props.className || 'option';
+
+  return (
+    <div className={optionName}>
+      <div className='option-icon'>
+        <FontAwesomeIcon icon={props.iconName} />
+      </div>
+
+      <div className='option-text'>{props.Text}</div>
+    </div>
+  );
+};
+
+export default Option;

--- a/gillajabi/src/styles/components/Navbar.css
+++ b/gillajabi/src/styles/components/Navbar.css
@@ -2,13 +2,22 @@
     height: 10%;
     width: 100%;
     display: flex;
-    border-bottom-style: solid;
-    border-bottom-color: #b1b9c8;
-    border-bottom-width: 1px;
+    justify-content: space-around;
+    border-bottom: 1px solid #b1b9c8 ;
 
-    @media (max-width: 320px) {
-        /* 320px 이하일 때의 스타일 적용 */
+    @media (max-width:344px)  {
+        font-size: 0.6rem;
+      }
+
+    @media (min-width: 345px) and (max-width:449px)  {
         font-size: 0.8rem;
       }
+
+    @media (min-width: 450px) and (max-width:574px)  {
+        font-size: 1rem;
+      }
+
+    @media (min-width: 575px) {
+        font-size: 1.2rem;
+    }
   }
-  

--- a/gillajabi/src/styles/components/Navbar.css
+++ b/gillajabi/src/styles/components/Navbar.css
@@ -1,0 +1,14 @@
+.navbar {
+    height: 10%;
+    width: 100%;
+    display: flex;
+    border-bottom-style: solid;
+    border-bottom-color: #b1b9c8;
+    border-bottom-width: 1px;
+
+    @media (max-width: 320px) {
+        /* 320px 이하일 때의 스타일 적용 */
+        font-size: 0.8rem;
+      }
+  }
+  

--- a/gillajabi/src/styles/components/Option.css
+++ b/gillajabi/src/styles/components/Option.css
@@ -2,15 +2,14 @@
     display: flex;
     flex-direction: column;
     justify-content: center;
-    width: 100%;
-    margin: 3% 0;
+    margin: 3% 0px;
   }
   
   .option .option-icon {
     display: flex;
     justify-content: center;
-    font-size: 1.5em;
-    margin-bottom: 5%;
+    font-size: 2.2em;
+    margin-bottom: 10%;
     color: #b1b9c8;
   }
   
@@ -18,5 +17,5 @@
     display: flex;
     font-weight: bold;
     justify-content: center;
-    font-size: 0.5em;
+    font-size: 1em;
   }

--- a/gillajabi/src/styles/components/Option.css
+++ b/gillajabi/src/styles/components/Option.css
@@ -1,0 +1,22 @@
+.option {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    width: 100%;
+    margin: 3% 0;
+  }
+  
+  .option .option-icon {
+    display: flex;
+    justify-content: center;
+    font-size: 1.5em;
+    margin-bottom: 5%;
+    color: #b1b9c8;
+  }
+  
+  .option .option-text {
+    display: flex;
+    font-weight: bold;
+    justify-content: center;
+    font-size: 0.5em;
+  }


### PR DESCRIPTION
### 📃 작업 내용

- 로그인 상태, 페이지 상태, 구독 상태에 따라 다른 Navbar 생성
- 로그인 상태 -> 로그인 유무에 따라 메인 페이지에 내 정보 or 로그인 하기 기능 추가
- 페이지 상태 -> 다른 페이지 일 때 이전 화면, 처음 화면 기능 추가
- 구독 상태 -> 구독 중 일 때 오늘의 문제, 불러오기 기능 추가
- Navbar에서 하나의 기능을 수행하는 공통 옵션 컴포넌트 구현 및 사용
- 공통 옵션 컴포넌트 -> 상단에 fontawesome Icon과 하단에 설명 Text로 구성 / className ( default : 'option') 으로 옵션 컴포넌트 스타일 설정

### 😎 PR 타입

- [x]  기능 추가
- [ ]  기능 삭제
- [ ]  버그 수정
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트

### 🌿 반영 브랜치

- 0jaemin0/navbar -> develop

### ❕ 참고 사항

- 로그인 상태, 페이지 상태, 구독 상태에 따라 Navbar가 달라짐으로 조건에 따라 올바른 Navbar 생성 및 크기에 문제가 있을 경우 말씀해 주세요

### 👀 미리보기

![image](https://github.com/Team-Columbus/Gillajabi-FE/assets/127086869/d739bb4e-c1e2-434f-b00d-d91474e6a4dd)

![image](https://github.com/Team-Columbus/Gillajabi-FE/assets/127086869/86613e9b-3f96-48ba-a8a2-f27e179a4c33)

![image](https://github.com/Team-Columbus/Gillajabi-FE/assets/127086869/79374669-d7f3-4e09-a396-af009defad32)

![image](https://github.com/Team-Columbus/Gillajabi-FE/assets/127086869/e5008a76-f7ba-4435-9f90-d1653c0a06cd)
