### PR TITLE
공통 문장 컴포넌트 구현

### DIFF
--- a/gillajabi/src/components/Sentence.jsx
+++ b/gillajabi/src/components/Sentence.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import '../styles/components/Sentence.css';
+
+const Sentence = (props) => {
+  return (
+    <div className='sentence'>
+      <p>{props.mainSentence}</p>
+      <p>{props.subSentence}</p>
+    </div>
+  );
+};
+
+export default Sentence;

--- a/gillajabi/src/styles/components/Sentence.css
+++ b/gillajabi/src/styles/components/Sentence.css
@@ -1,6 +1,21 @@
 .sentence {
   width: 80%;
   margin: 8% 10%;
+  @media (max-width: 344px) {
+    font-size: 0.95rem;
+  }
+
+  @media (min-width: 345px) and (max-width: 449px) {
+    font-size: 1.15rem;
+  }
+
+  @media (min-width: 450px) and (max-width: 574px) {
+    font-size: 1.55rem;
+  }
+
+  @media (min-width: 575px) {
+    font-size: 2rem;
+  }
 }
 
 .sentence p:first-child {

--- a/gillajabi/src/styles/components/Sentence.css
+++ b/gillajabi/src/styles/components/Sentence.css
@@ -1,0 +1,15 @@
+.sentence {
+  width: 80%;
+  margin: 8% 10%;
+}
+
+.sentence p:first-child {
+  font-weight: bold;
+  font-size: 1em;
+}
+
+.sentence p:last-child {
+  font-size: 0.7em;
+  font-weight: bold;
+  color: #767d88;
+}


### PR DESCRIPTION
### 📃 작업 내용

-  첫 번째 줄에 메인 문장을 두 번째 줄에 서브 문장을 출력하도록 구현
- 메인 문장은 상대적으로 크고 진한 색상으로 서브 문장은 작고 연한 색상으로 스타일 설정

### 😎 PR 타입

- [x]  기능 추가
- [ ]  기능 삭제
- [ ]  버그 수정
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트

### 🌿 반영 브랜치

- 0jaemin0/sentence -> develop

### ❕ 참고 사항

- 사이즈마다 글자 크기를 설정해 두었으나 자연스럽지 않다거나 변경하고 싶은 사항 있으시면 말씀해 주세요

### 👀 미리보기
![image](https://github.com/Team-Columbus/Gillajabi-FE/assets/127086869/81c0a4bf-f329-446f-a036-a5a697c1d144)
