### PR TITLE
zoom 기능 추가 구현

### DIFF
--- a/gillajabi/src/App.css
+++ b/gillajabi/src/App.css
@@ -11,10 +11,20 @@ body {
   box-sizing: border-box;
   border: 2px solid black;
   height : 100vh;
+  transform-origin: top left;
+  transition: transform 0.3s ease-in-out;
+  overflow: hidden;
 
   @media (min-width: 769px) {
     /* 769px 이상일 때의 스타일 적용 */
   }
+}
 
-  overflow: auto;
+/* zoom Button */
+.app-zoombuttons-container{
+  position: absolute;
+  width : 10%;
+  max-width: 40px;
+  bottom: 0;
+  right: 0;
 }

--- a/gillajabi/src/App.js
+++ b/gillajabi/src/App.js
@@ -2,12 +2,18 @@ import React, { useState, useEffect } from 'react'
 import { BrowserRouter, Route, Routes } from 'react-router-dom'
 import { Main, Splash, Signup, Login, Mypage, Category} from './pages'
 import { useUserStore } from './stores/userStore';
+import { useZoomStore } from './stores/zoomStore';
 import PrivateRoute from './components/PrivateRoute';
+import ZoomButtons from './components/ZoomButtons'
 import './App.css'
 
 function App() {
   const [showSplash, setShowSplash] = useState(true);
   const { getUserInfo } = useUserStore();
+  const { zoomLevel } = useZoomStore();
+  const mainStyle = {
+    transform: `scale(${zoomLevel / 100})`,
+  };
 
   useEffect(() => {
     const visited = sessionStorage.getItem('visited');
@@ -32,7 +38,7 @@ function App() {
   }, []);
 
   return (
-    <div className='app'>
+    <div className='app' style={mainStyle}>
       <BrowserRouter>
         <Routes>
           {showSplash ? <Route path="/" element={<Splash />} />
@@ -46,6 +52,11 @@ function App() {
             </>
           )}
         </Routes>
+        {!showSplash && (
+          <div className='app-zoombuttons-container'>
+            <ZoomButtons />
+          </div>
+        )}
       </BrowserRouter>
     </div>
   );

--- a/gillajabi/src/Hooks/useReset.jsx
+++ b/gillajabi/src/Hooks/useReset.jsx
@@ -1,0 +1,11 @@
+import { useEffect } from 'react';
+import { useZoomStore } from '../stores/zoomStore';
+
+export default function useReset() {
+  document.documentElement.style.transform = '';
+  const { resetZoom } = useZoomStore();
+  
+  useEffect(() => {
+    resetZoom();
+  }, []);
+}

--- a/gillajabi/src/components/Navbar.jsx
+++ b/gillajabi/src/components/Navbar.jsx
@@ -2,14 +2,14 @@ import React, { useEffect, useState } from 'react';
 import '../styles/components/Navbar.css';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { useUserStore } from '../stores/userStore';
-import { faUser, faHouse, faDownload, faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons';
-import { faCircleQuestion, faCircleLeft } from '@fortawesome/free-regular-svg-icons';
 import {Back, Glasses, Home, Load, Login, myInfo, Solve} from '../assets/'
+import { useZoomStore } from '../stores/zoomStore';
 
 const Navbar = () => {
   const { user } = useUserStore();
   const location = useLocation();
   const navigate = useNavigate();
+  const { handleZoom } = useZoomStore();
 
   const [isMain, setIsMain] = useState(false);
   const [isSubscribe, setIsSubscribe] = useState(false);
@@ -30,37 +30,37 @@ const Navbar = () => {
       {/* 메인페이지일 경우: 로그인 또는 이전화면 */}
       {isMain ? (
         <div className='navbar-img' onClick={mainPageFunction}>
-          <img src= {mainPageImg} />
+          <img src= {mainPageImg} alt='myInfo/Login'/>
         </div>
       ) : (
         <div className='navbar-img' onClick={() => navigate(-1)}>
-          <img src= {Back} />
+          <img src= {Back} alt='back'/>
         </div>        
       )}
 
       {/* 구독 상태일 경우: 오늘의 문제 */}
       {isSubscribe && (
         <div className='navbar-img' onClick={() => navigate('question')}>
-          <img src= {Solve} />
+          <img src= {Solve} alt='solve'/>
         </div>        
       )}
 
       {/* 메인 페이지가 아닐 경우: 처음화면 */}
       {!isMain &&         
         <div className='navbar-img' onClick={() => navigate('/')}>
-          <img src= {Home} />
+          <img src= {Home} alt='home'/>
         </div>
       }
 
       {/* 구독 상태일 경우: 불러오기 */}
       {isSubscribe && 
         <div className='navbar-img' onClick={() => navigate('/load')}>
-          <img src= {Load} />
+          <img src= {Load} alt='load'/>
         </div>
       }
       
-      <div className='navbar-img'>
-        <img src= {Glasses} />
+      <div className='navbar-img' onClick={handleZoom}>
+        <img src= {Glasses} alt='glasses'/>
       </div>
     </div>
   );

--- a/gillajabi/src/components/ZoomButtons.jsx
+++ b/gillajabi/src/components/ZoomButtons.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { useZoomStore } from '../stores/zoomStore';
+import '../styles/components/ZoomButtons.css';
+
+const ZoomButtons = () => {
+  const { toggleZoom, zoomIn, zoomOut, resetZoom } = useZoomStore();
+
+  return (
+    <div className={`zoom-glass ${toggleZoom ? 'slideOutFromRight' : 'slideInFromRight'}`}>
+      <button onClick={zoomIn}>+</button>
+      <button onClick={resetZoom}>Ο</button>
+      <button onClick={zoomOut}>-</button>
+    </div>
+  );
+};
+
+export default ZoomButtons;

--- a/gillajabi/src/pages/Main/Main.jsx
+++ b/gillajabi/src/pages/Main/Main.jsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import Navbar from '../../components/Navbar';
 import Sentence from '../../components/Sentence';
+import useReset from '../../Hooks/useReset';
 import '../../styles/pages/Main.css'
 import {Atm, Cafe, Cinema, fastFood, Machine, Traffic} from '../../assets/'
 
 const Main = () => {
+  useReset();
   const mainSentence = '어떤 분야의 학습을 원하시나요?';
   const subSentence = '원하시는 분야를 눌러주세요.';
 
@@ -17,7 +19,7 @@ const Main = () => {
       <div className='main-category'>
         {categoryList.map((info, index) => (
           <div className='main-categoryImg'>
-            <img src = {info}/>
+            <img src = {info} alt='categoryImg'/>
           </div>
         ))}
       </div>

--- a/gillajabi/src/stores/zoomStore.jsx
+++ b/gillajabi/src/stores/zoomStore.jsx
@@ -1,0 +1,31 @@
+import { create } from 'zustand';
+
+export const useZoomStore = create((set, get) => ({
+  toggleZoom: false,
+  zoomLevel: 100,
+
+  setToggleZoom: (value) => set({ toggleZoom: value }),
+
+  handleZoom: () => {
+    const currentZoom = get().toggleZoom;
+    set({ toggleZoom: !currentZoom });
+  },
+
+  zoomIn: () => {
+    const currentZoom = get().zoomLevel;
+    if (currentZoom < 120) {
+      set({ zoomLevel: currentZoom + 4 });
+    }
+  },
+
+  zoomOut: () => {
+    const currentZoom = get().zoomLevel;
+    if (currentZoom > 100) {
+      set({ zoomLevel: currentZoom - 4 });
+    }
+  },
+
+  resetZoom: () => {
+    set({ zoomLevel: 100 });
+  },
+}));

--- a/gillajabi/src/styles/components/ZoomButtons.css
+++ b/gillajabi/src/styles/components/ZoomButtons.css
@@ -1,0 +1,50 @@
+.zoom-glass {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 50px;
+  aspect-ratio: 1 / 2 ;
+  z-index: 2;
+}
+.zoom-glass button {
+  box-sizing: border-box;
+  aspect-ratio: 1;
+  border : 2px solid #ff911b;
+  background-color: #ffffff;
+  border-radius: 100%;
+  margin-bottom: 0.5em;
+  box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.5);
+}
+.zoom-glass button:hover {
+  color: #ffffff;
+  background-color: #ff911b;
+}
+.slideInFromRight {
+animation: slideInButton 0.5s forwards;
+}
+.slideOutFromRight {
+animation: slideOutButton 0.5s forwards;
+}
+
+@keyframes slideInButton {
+  from {
+    transform: translateY(100%);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+@keyframes slideOutButton {
+  from {
+    transform: translateY(0);
+    opacity: 1;
+  }
+  to {
+    transform: translateY(100%);
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
### 📃 작업 내용

- 화면 확대 / 초기화 / 축소할 수 있는 기능을 지닌ZoomButtons 컴포넌트 추가
- 돋보기 아이콘에 ZoomButtons 컴포넌트 토글 기능 추가  
- zoom 기능 관리를 위한 zoomStore 추가
- ZoomButtons는 app의 우측 하단에 위치
- 페이지 마운트 시 scale을 초기화하는 기능을 담은 useReset 커스텀 훅 추가

### 😎 PR 타입

- [x]  기능 추가
- [ ]  기능 삭제
- [ ]  버그 수정
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트

### 🌿 반영 브랜치

- ledraco/zoom -> develop

### ❕ 참고 사항
- 현재 모바일 환경에서 scale을 키운 상태로 페이지 이동할 경우 마운트 시 scale 값을 1로 조정해도 이전 크기를 반영하여 html보다 화면이 커진 상태를 가지는 이슈가 있음.

### 👀 미리보기
![image](https://github.com/Team-Columbus/Gillajabi-FE/assets/98178673/82d7724e-2fb6-4b9f-bc27-91f712ca3576)
