### PR TITLE
유형 페이지 구현

### DIFF
--- a/gillajabi/src/App.js
+++ b/gillajabi/src/App.js
@@ -48,8 +48,8 @@ function App() {
               <Route path="/signup" element={<Signup />} />
               <Route path="/login" element={<Login />} />
               <Route path="/mypage" element={<PrivateRoute component={<Mypage/>}/>} />
-              <Route path="/category" element={<Category />} />
-              <Route path="/practice" element={<Practice />} />
+              <Route path="/category/:id" element={<Category />} />
+              <Route path="/practice/:id" element={<Practice />} />
             </>
           )}
         </Routes>

--- a/gillajabi/src/pages/Category/Category.jsx
+++ b/gillajabi/src/pages/Category/Category.jsx
@@ -1,9 +1,48 @@
 import React from 'react';
+import Navbar from '../../components/Navbar'
+import Sentence from '../../components/Sentence'
+import { Cafe, Cinema, fastFood, Traffic} from '../../assets/'
+import { useParams, useNavigate } from 'react-router-dom';
+import '../../styles/pages/Category.css'
 
 const Category = () => {
+  const params = useParams(); 
+  const kindId = params.id;
+
+  const mainSentence = kindId
+  const subSentence = '원하시는 분야를 눌러주세요'
+  const navigate = useNavigate();
+  
+  const movePractice = (category) => {
+    navigate(`/practice/${category}`)
+  }
+
   return (
-    <div>
-      카테고리 페이지입니다.
+    <div className='category'>
+      <Navbar />
+      <Sentence mainSentence={mainSentence} subSentence={subSentence} />
+      <div className='category-kind'>
+        {kindId === '패스트푸드' && Array.from({ length: 3 }).map((_, index) => (
+          <div className='category-kindImg' onClick={() => movePractice(kindId)}>
+            <img src={fastFood} alt='fastFood' key={index} />
+          </div>
+        ))}
+        {kindId === '영화관' && Array.from({ length: 3 }).map((_, index) => (
+          <div className='category-kindImg' onClick={() => movePractice(kindId)}>
+            <img src={Cinema} alt='Cinema' key={index} />
+          </div>
+        ))}
+        {kindId === '카페' && Array.from({ length: 3 }).map((_, index) => (
+          <div className='category-kindImg' onClick={() => movePractice(kindId)}>
+            <img src={Cafe} alt='Cafe' key={index} />
+          </div>
+        ))}
+        {kindId === '교통' && Array.from({ length: 2 }).map((_, index) => (
+          <div className='category-kindImg' onClick={() => movePractice(kindId)} id='Traffic'>
+            <img src={Traffic} alt='Traffic' key={index} />
+          </div>
+        ))}
+      </div>
     </div>
   );
 };

--- a/gillajabi/src/pages/Main/Main.jsx
+++ b/gillajabi/src/pages/Main/Main.jsx
@@ -2,15 +2,34 @@ import React from 'react';
 import Navbar from '../../components/Navbar';
 import Sentence from '../../components/Sentence';
 import useReset from '../../Hooks/useReset';
-import '../../styles/pages/Main.css'
 import {Atm, Cafe, Cinema, fastFood, Machine, Traffic} from '../../assets/'
+import { useNavigate } from 'react-router-dom';
+import '../../styles/pages/Main.css'
 
 const Main = () => {
   useReset();
   const mainSentence = '어떤 분야의 학습을 원하시나요?';
   const subSentence = '원하시는 분야를 눌러주세요.';
+  const navigate = useNavigate();
 
-  const categoryList = [ fastFood, Cinema, Cafe, Traffic, Machine, Atm];
+  const categoryList = [ '패스트푸드', '영화관', '카페', '교통', '무인민원발급기', 'ATM'];
+  
+  const imageMap = {
+    패스트푸드: fastFood,
+    영화관: Cinema,
+    카페: Cafe,
+    교통: Traffic,
+    무인민원발급기: Machine,
+    ATM: Atm
+  };
+
+  const moveCategory = (category) => {
+    navigate(`/category/${category}`)
+  }
+
+  const movePractice = (category) => {
+    navigate(`/practice/${category}`)
+  }
 
   return (
     <div className='main'> 
@@ -18,8 +37,8 @@ const Main = () => {
       <Sentence mainSentence={mainSentence} subSentence={subSentence} />
       <div className='main-category'>
         {categoryList.map((info, index) => (
-          <div className='main-categoryImg'>
-            <img src = {info} alt='categoryImg'/>
+          <div className='main-categoryImg' onClick={info === '무인민원발급기' || info === 'ATM' ? () => movePractice(info) : () => moveCategory(info)} key={index}>
+            <img src={imageMap[info]} alt='categoryImg' />
           </div>
         ))}
       </div>

--- a/gillajabi/src/pages/Practice/Practice.jsx
+++ b/gillajabi/src/pages/Practice/Practice.jsx
@@ -2,11 +2,15 @@ import React from 'react';
 import Navbar from '../../components/Navbar'
 import Sentence from '../../components/Sentence'
 import {Preview, Together, Alone} from '../../assets'
-import '../../styles/pages/Practice.css'
 import Select from '../../components/Select'
+import { useParams } from 'react-router-dom';
+import '../../styles/pages/Practice.css'
 
 const Practice = () => {
-  const mainSentence = '테스트'
+  const params = useParams(); 
+  const practiceId = params.id;
+
+  const mainSentence = practiceId
   const subSentence = '원하시는 연습 방식을 선택해주세요'
 
   const previewPage = () => {

--- a/gillajabi/src/styles/pages/Category.css
+++ b/gillajabi/src/styles/pages/Category.css
@@ -1,0 +1,48 @@
+.category {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  height: 100%;
+  overflow-y: scroll
+}
+
+.category-kind {
+  display: flex;
+  flex-direction: column;
+  width: 80%;
+  height: 65%;
+  gap: 5%;
+
+  /* 휴대폰 가로 */
+  @media  (max-height:480px) and (max-width:900px) and (orientation: landscape) {
+    flex-direction: row;
+    height: 40%;
+    margin-bottom: 5%;
+  }
+
+    /* 탭 가로 (모니터 포함)*/
+  @media (min-width:1024px) and (max-height :1025px) and (orientation: landscape) {
+    height: 62%;
+  }
+}
+
+.category-kindImg {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  overflow: hidden;
+  width: 100%;
+}
+
+#Traffic img {
+  height: 65%;
+
+  /* 휴대폰 가로 */
+  @media  (max-height:480px) and (max-width:900px) and (orientation: landscape) {
+    height: 100%;
+  }
+}
+
+.category-kindImg img {
+  height: 100%;
+}

--- a/gillajabi/src/styles/pages/Main.css
+++ b/gillajabi/src/styles/pages/Main.css
@@ -3,6 +3,8 @@
   flex-direction: column;
   align-items: center;
   height: 100%;
+  overflow-y: scroll
+
 }
 
 .main-category {


### PR DESCRIPTION
### 📃 작업 내용

- 하나의 카테고리에 대한 여러가지 유형을 보여주는 유형 페이지 구현
- 유형 페이지
    - 패스트푸드, 영화관, 카페, 교통 카테고리에 대한 유형 개수에 맞게 유형 출력
    - 무인민원발급기, ATM은 별다른 유형이 없음으로 출력하지 않음
    - 휴대폰 가로모드시 여러 가지 유형을 가로로 배치하기 위한 미디어 쿼리 설정
  
- 메인 페이지에서 각 카테고리 클릭 시 유형 페이지로 이동하는 동작 구현
    - 패스트푸드, 영화관, 카페, 교통 카테고리는 유형 존재 => 클릭 시 유형 페이지로 이동
    - 무인민원발급기, ATM 은 별다른 유형 존재하지 않음 => 클릭 시 연습 페이지로 이동

- useParams를 사용해 유형 페이지, 연습 페이지에 카테고리 제목 출력 => 카테고리 이름 전달을 위한 라우트 path 수정

### 😎 PR 타입

- [x]  기능 추가
- [ ]  기능 삭제
- [ ]  버그 수정
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트

### 🌿 반영 브랜치

- 0jaemin0/categorypage -> develop

### ❕ 참고 사항

- 반응형 및 페이지 이동에 문제 발견 시 말씀해 주세요
- 유형 페이지에 적합한 이미지 발견 시 말씀해 주세요

### 👀 미리보기

![유형 페이지](https://github.com/Team-Columbus/Gillajabi-FE/assets/127086869/2cc87a96-1534-45be-bc79-dad87d50e358)