### PR TITLE
미리보기 페이지 구현

### DIFF
--- a/gillajabi/src/App.js
+++ b/gillajabi/src/App.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import { BrowserRouter, Route, Routes } from 'react-router-dom'
-import { Main, Splash, Signup, Login, Mypage, Category, Practice, Level} from './pages'
+import { Main, Splash, Signup, Login, Mypage, Category, Practice, Level, Preview} from './pages'
 import { useUserStore } from './stores/userStore';
 import { useZoomStore } from './stores/zoomStore';
 import PrivateRoute from './components/PrivateRoute';
@@ -51,6 +51,7 @@ function App() {
               <Route path="/category/:path" element={<Category />} />
               <Route path="/practice/:path" element={<Practice />} />
               <Route path="/level/:path" element={<Level />} />
+              <Route path="/preview/:path" element={<Preview />} />
             </>
           )}
         </Routes>

--- a/gillajabi/src/pages/Practice/Practice.jsx
+++ b/gillajabi/src/pages/Practice/Practice.jsx
@@ -15,7 +15,7 @@ const Practice = () => {
   const subSentence = '원하시는 연습 방식을 선택해주세요'
 
   const previewPage = () => {
-    //미리보기
+    navigate(`/preview/${practicePath}`)
   }
 
   const togetherPage = () => {

--- a/gillajabi/src/pages/Preview/Preview.jsx
+++ b/gillajabi/src/pages/Preview/Preview.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import Navbar from '../../components/Navbar'
+import Sentence from '../../components/Sentence'
+import { useParams } from 'react-router-dom';
+import '../../styles/pages/Preview.css'
+
+const Preview = () => {
+  const params = useParams(); 
+  const previewPath = params.path;
+
+  const mainSentence = previewPath
+  const subSentence = '전체적인 학습 흐름을 미리보아요'
+
+  return (
+    <div className='preview'>
+      <Navbar />
+      <Sentence mainSentence={mainSentence} subSentence={subSentence} />
+      <div className="preview-video">
+        <iframe
+          src="https://www.youtube.com/embed/dMLad81xzog"
+          frameborder="0"
+          allow="fullscreen"
+        >
+        </iframe>
+      </div>
+    </div>
+  );
+};
+
+export default Preview;

--- a/gillajabi/src/pages/Preview/index.js
+++ b/gillajabi/src/pages/Preview/index.js
@@ -1,0 +1,1 @@
+export { default as Preview } from './Preview';

--- a/gillajabi/src/pages/index.js
+++ b/gillajabi/src/pages/index.js
@@ -6,3 +6,4 @@ export { Mypage } from './Mypage';
 export { Main } from './Main';
 export { Practice } from './Practice';
 export { Level } from './Level';
+export { Preview } from './Preview';

--- a/gillajabi/src/styles/pages/Preview.css
+++ b/gillajabi/src/styles/pages/Preview.css
@@ -1,0 +1,27 @@
+.preview {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  height: 100%;
+
+  /* 휴대폰 가로 */
+  @media  (max-height:480px) and (max-width:900px) and (orientation: landscape) {
+    overflow-y: scroll
+  }
+}
+
+.preview-video {
+  width: 80%;
+  height: 70%;
+}
+
+.preview-video iframe {
+  height: 90%;
+  width: 100%;
+
+  /* 휴대폰 가로 */
+  @media  (max-height:480px) and (max-width:900px) and (orientation: landscape) {
+    height: 140%;
+    margin-bottom: 10%;
+  }
+}


### PR DESCRIPTION
### 📃 작업 내용

- 하나의 카테고리에 대한 진행 과정을 영상으로 보여주는 미리보기 페이지 구현
- 유튜브 영상을 제공
- 연습 페이지에서 미리보기 클릭 시 미리보기 페이지로 이동

### 😎 PR 타입

- [x]  기능 추가
- [ ]  기능 삭제
- [ ]  버그 수정
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트

### 🌿 반영 브랜치

- 0jaemin0/previewpage -> develop

### ❕ 참고 사항

- 현재 임의의 유튜브 영상을 제공하고 있으며 추후 현재 서비스의 미리 보기 영상으로 변경하겠습니다

### 👀 미리보기

![미리보기 페이지](https://github.com/Team-Columbus/Gillajabi-FE/assets/127086869/05f566a7-cd6a-4d7f-9d88-f6edda3b7c40)