### PR TITLE
카테고리별 페이지 라우팅 및 페이지 디자인 추가

### DIFF
--- a/gillajabi/src/pages/Main/Main.jsx
+++ b/gillajabi/src/pages/Main/Main.jsx
@@ -23,11 +23,24 @@ const Main = () => {
     ATM: Atm
   };
 
-  const moveCategory = (category) => {
-    navigate(`/category/${category}`)
+  const moveMovie = () => {
+    navigate('/movie')
+  }
+
+  const moveBus = () => {
+    navigate('/bus')
   }
 
   const movePractice = (category) => {
+    if (category === '영화관') {
+      moveMovie();
+      return null;
+    }
+    
+    if(category === '교통') {
+      moveBus();
+      return null;
+    }
     navigate(`/practice/${category}`)
   }
 
@@ -37,8 +50,8 @@ const Main = () => {
       <Sentence mainSentence={mainSentence} subSentence={subSentence} />
       <div className='main-category'>
         {categoryList.map((info, index) => (
-          <div className='main-categoryImg' onClick={info === '무인민원발급기' || info === 'ATM' ? () => movePractice(info) : () => moveCategory(info)} key={index}>
-            <img src={imageMap[info]} alt='categoryImg' />
+          <div className='main-categoryImg' onClick={ () => movePractice(info)}  key={index}>
+            <img src={imageMap[info]} alt='categoryImg'/>
           </div>
         ))}
       </div>

--- a/gillajabi/src/styles/pages/Category.css
+++ b/gillajabi/src/styles/pages/Category.css
@@ -3,7 +3,10 @@
   flex-direction: column;
   align-items: center;
   height: 100%;
-  overflow-y: scroll
+  /* 휴대폰 가로 */
+  @media  (max-height:480px) and (max-width:900px) and (orientation: landscape) {
+    overflow-y: scroll
+  }
 }
 
 .category-kind {

--- a/gillajabi/src/styles/pages/Main.css
+++ b/gillajabi/src/styles/pages/Main.css
@@ -3,8 +3,10 @@
   flex-direction: column;
   align-items: center;
   height: 100%;
-  overflow-y: scroll
-
+  /* 휴대폰 가로 */
+  @media  (max-height:480px) and (max-width:900px) and (orientation: landscape) {
+    overflow-y: scroll
+  }
 }
 
 .main-category {

--- a/gillajabi/src/styles/pages/Practice.css
+++ b/gillajabi/src/styles/pages/Practice.css
@@ -3,7 +3,10 @@
   flex-direction: column;
   align-items: center;
   height: 100%;
-  overflow-y: scroll;
+  /* 휴대폰 가로 */
+  @media  (max-height:480px) and (max-width:900px) and (orientation: landscape) {
+    overflow-y: scroll
+  }
 } 
 
 .practice-space {


### PR DESCRIPTION
### 📃 작업 내용

- 메인 페이지에서 각 카테고리별 페이지 이동 수정
    - 영화관, 교통 카테고리 -> 키오스크 페이지로 이동
    - 나머지 카테고리 -> 연습 방법 페이지로 이동
    
- 전체적인 페이지 휴대폰 가로모드시 수직 스크롤 생성 추가

### 😎 PR 타입

- [x]  기능 추가

### 🌿 반영 브랜치

- 0jaemin0/pagestyle -> develop

### ❕ 참고 사항

- 모니터 화면에서 수직 스크롤이 생성되는 페이지 발견 시 말씀해 주세요.

### 👀 미리보기

![메인 페이지 - 수정](https://github.com/Team-Columbus/Gillajabi-FE/assets/127086869/75287d4a-d8e3-4d12-a631-7d76afac76a6)

![연습 방법 페이지 - 수정](https://github.com/Team-Columbus/Gillajabi-FE/assets/127086869/90d2885f-3408-444b-ac40-f268c75f19fc)


