### PR TITLE
퀘스트 기능 구현

### DIFF
--- a/gillajabi/src/App.js
+++ b/gillajabi/src/App.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import { BrowserRouter, Route, Routes } from 'react-router-dom'
-import { Main, Splash, Signup, Login, Mypage, Category, Practice, Level, Preview, Edit, Movie, Bus} from './pages'
+import { Main, Splash, Signup, Login, Mypage, Category, Practice, Level, Preview, Edit, Movie, Bus, Quest} from './pages'
 import { useUserStore } from './stores/userStore';
 import { useZoomStore } from './stores/zoomStore';
 import PrivateRoute from './components/PrivateRoute';
@@ -48,6 +48,7 @@ function App() {
               <Route path="/signup" element={<Signup />} />
               <Route path="/login" element={<Login />} />
               <Route path="/mypage" element={<PrivateRoute component={<Mypage/>}/>} />
+              <Route path="/quest" element={<PrivateRoute component={<Quest/>}/>} />
               <Route path="/category/:path" element={<Category />} />
               <Route path="/practice/:path" element={<Practice />} />
               <Route path="/level/:path" element={<Level />} />

--- a/gillajabi/src/components/Navbar.jsx
+++ b/gillajabi/src/components/Navbar.jsx
@@ -40,7 +40,7 @@ const Navbar = () => {
 
       {/* 구독 상태일 경우: 오늘의 문제 */}
       {isSubscribe && (
-        <div className='navbar-img' onClick={() => navigate('question')}>
+        <div className='navbar-img' onClick={() => navigate('quest')}>
           <img src= {Solve} alt='solve'/>
         </div>        
       )}

--- a/gillajabi/src/pages/Movie/components/MoviePurchase/MoviePrintTicketModal.jsx
+++ b/gillajabi/src/pages/Movie/components/MoviePurchase/MoviePrintTicketModal.jsx
@@ -61,7 +61,6 @@ const MoviePrintTicketModal = () => {
           },
         }
       );
-      console.log(response.data);
     } catch (error) {
       console.error(error.message);
     }

--- a/gillajabi/src/pages/Quest/Quest.jsx
+++ b/gillajabi/src/pages/Quest/Quest.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import MovieQuest from './components/MovieQuest';
 import Navbar from '../../components/Navbar';
 import Button from '../../components/Button';
 import axios from 'axios';
@@ -30,6 +31,7 @@ const Quest = () => {
 
   switch (quest?.content.category) {
     case '영화관':
+      questComponent = <MovieQuest info={quest.content}/>
       questId='movie'
       break;
     case '버스':

--- a/gillajabi/src/pages/Quest/Quest.jsx
+++ b/gillajabi/src/pages/Quest/Quest.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import Navbar from '../../components/Navbar';
+
+const Quest = () => {
+  return (
+    <div className='quest'>
+      <Navbar/>
+      퀘스트 페이지 입니다.
+    </div>
+  );
+};
+
+export default Quest;

--- a/gillajabi/src/pages/Quest/Quest.jsx
+++ b/gillajabi/src/pages/Quest/Quest.jsx
@@ -1,13 +1,15 @@
 import React, { useEffect, useState } from 'react';
 import MovieQuest from './components/MovieQuest';
 import Navbar from '../../components/Navbar';
-import Button from '../../components/Button';
+import QuestButton from './components/QuestButton';
 import axios from 'axios';
 import '../../styles/pages/Quest.css';
 
 const Quest = () => {
 
   const [quest, setQuest] = useState(null);
+  const [isAccept, setIsAccept] = useState(false);
+  const [isDone, setIsDone] = useState(false);
 
   let questComponent;
   let questId;
@@ -25,6 +27,8 @@ const Quest = () => {
         },
       });
       setQuest(response.data);
+      setIsAccept(response.data.is_accept);
+      setIsDone(response.data.is_do);
     } catch (error) {
       console.error(error.message);
     }
@@ -60,9 +64,7 @@ const Quest = () => {
             </div>
           </div>
         </div>
-        <Button>
-          수락하기
-        </Button>
+        <QuestButton isAccept={isAccept} isDone={isDone} setIsAccept={setIsAccept}/>
       </div>
     </div>
   );

--- a/gillajabi/src/pages/Quest/Quest.jsx
+++ b/gillajabi/src/pages/Quest/Quest.jsx
@@ -1,11 +1,66 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import Navbar from '../../components/Navbar';
+import Button from '../../components/Button';
+import axios from 'axios';
 
 const Quest = () => {
+
+  const [quest, setQuest] = useState(null);
+
+  let questComponent;
+  let questId;
+
+  useEffect(()=>{
+    getQuestInfo();
+  },[]);
+
+  const getQuestInfo = async () =>{
+    const token = localStorage.getItem('accessToken');
+    try {
+      const response = await axios.get(`${process.env.REACT_APP_API}/api/quests/`, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+      setQuest(response.data);
+    } catch (error) {
+      console.error(error.message);
+    }
+  }
+
+  switch (quest?.content.category) {
+    case '영화관':
+      questId='movie'
+      break;
+    case '버스':
+      questId='transport'
+      break;
+    default:
+      questComponent = undefined;
+      break;
+  };
+
   return (
     <div className='quest'>
       <Navbar/>
-      퀘스트 페이지 입니다.
+      <div className='quest-content'>
+        <div className='quest-content-info'>
+          <div className='quest-content-header'>
+            <p>오늘의 문제</p>
+            <div className='quest-content-header-category' id={questId}>
+              <p>{quest?.content.category}</p>
+            </div>
+          </div>
+          <div className='quest-content-detail'>
+            <div className='quest-content-detail-component'>
+              {questComponent}
+            </div>
+          </div>
+        </div>
+        <Button>
+          수락하기
+        </Button>
+      </div>
     </div>
   );
 };

--- a/gillajabi/src/pages/Quest/Quest.jsx
+++ b/gillajabi/src/pages/Quest/Quest.jsx
@@ -3,6 +3,7 @@ import MovieQuest from './components/MovieQuest';
 import Navbar from '../../components/Navbar';
 import Button from '../../components/Button';
 import axios from 'axios';
+import '../../styles/pages/Quest.css';
 
 const Quest = () => {
 

--- a/gillajabi/src/pages/Quest/components/MovieQuest.jsx
+++ b/gillajabi/src/pages/Quest/components/MovieQuest.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+const MovieQuest = ({info}) => {
+
+  const userCount = info.ticket;
+  const matchType = {
+    'normal' : '일반',
+    'teen' : '청소년',
+    'disabled' : '우대',
+    'silver' : '경로',
+  }
+
+  return (
+    <div className='quest-moviequest'>
+      <p>시작 시간 {info.time}</p>
+      <p>{info.title}</p>
+      <div className='quest-moviequest-usercount'>
+        {Object.keys(userCount).map((type,idx) => (
+          userCount[type] !== 0 && 
+            <p key={idx}>{`${matchType[type]}`} {`${userCount[type]}`}매</p>
+          ))}
+      </div>
+      <p>예매해보기!</p>
+    </div>
+  );
+};
+
+export default MovieQuest;

--- a/gillajabi/src/pages/Quest/components/QuestButton.jsx
+++ b/gillajabi/src/pages/Quest/components/QuestButton.jsx
@@ -3,7 +3,7 @@ import Button from '../../../components/Button';
 import axios from 'axios';
 
 const QuestButton = ({ isAccept, isDone, setIsAccept }) => {
-  
+
   const [buttonStyle, setButtonStyle] = useState({
     styleType : 'Large_White',
     buttonText : '수락하기'
@@ -14,16 +14,15 @@ const QuestButton = ({ isAccept, isDone, setIsAccept }) => {
   },[isAccept, isDone]);
 
   const handleButtonStyle = () =>{
-    if (isDone) {
-      setButtonStyle({
-        styleType : 'Movie_Gray',
-        buttonText :'수행 완료',
-      });
-    } 
     if (isAccept) {    
       setButtonStyle({
         styleType : 'Large_Orange',
         buttonText : '수락 중',
+      });
+    } if (isDone) {
+      setButtonStyle({
+        styleType : 'Movie_Gray',
+        buttonText : '수행 완료',
       });
     } else {
       setButtonStyle({

--- a/gillajabi/src/pages/Quest/components/QuestButton.jsx
+++ b/gillajabi/src/pages/Quest/components/QuestButton.jsx
@@ -1,0 +1,59 @@
+import React, { useEffect, useState } from 'react';
+import Button from '../../../components/Button';
+import axios from 'axios';
+
+const QuestButton = ({ isAccept, isDone, setIsAccept }) => {
+  
+  const [buttonStyle, setButtonStyle] = useState({
+    styleType : 'Large_White',
+    buttonText : '수락하기'
+  });
+
+  useEffect(()=>{
+    handleButtonStyle();
+  },[isAccept, isDone]);
+
+  const handleButtonStyle = () =>{
+    if (isDone) {
+      setButtonStyle({
+        styleType : 'Movie_Gray',
+        buttonText :'수행 완료',
+      });
+    } 
+    if (isAccept) {    
+      setButtonStyle({
+        styleType : 'Large_Orange',
+        buttonText : '수락 중',
+      });
+    } else {
+      setButtonStyle({
+        styleType : 'Large_White',
+        buttonText : '수락하기',
+      });
+    };
+  }
+
+  const handleAcceptQuest = async () =>{
+    if (!isAccept && !isDone){
+      const token = localStorage.getItem('accessToken');
+      try {
+        const response = await axios.get(`${process.env.REACT_APP_API}/api/quests/accept/`, {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        });
+        setIsAccept(true);
+      } catch (error) {
+        console.error(error.message);
+      }
+    }
+  }
+
+  return (
+    <Button styleType={buttonStyle.styleType} onClick={handleAcceptQuest}>
+      {buttonStyle.buttonText}
+    </Button>
+  );
+};
+
+export default QuestButton;

--- a/gillajabi/src/pages/Quest/index.js
+++ b/gillajabi/src/pages/Quest/index.js
@@ -1,0 +1,1 @@
+export { default as Quest } from './Quest';

--- a/gillajabi/src/pages/index.js
+++ b/gillajabi/src/pages/index.js
@@ -10,3 +10,4 @@ export { Preview } from './Preview';
 export { Edit } from './Edit';
 export { Movie } from './Movie';
 export { Bus } from './Bus';
+export { Quest } from './Quest';

--- a/gillajabi/src/styles/pages/Quest.css
+++ b/gillajabi/src/styles/pages/Quest.css
@@ -1,0 +1,101 @@
+.quest{
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  height: 100%;
+}
+.quest p {
+  margin : 0;
+  padding: 0;
+}
+
+/* 퀘스트 콘텐츠 */
+.quest-content{
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height : 100%;
+  width : 100%;
+}
+.quest-content-info{
+  width : 100%;
+  height : 70%;
+}
+
+/* 퀘스트 콘텐츠 header*/
+.quest-content-header{
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width : 100%;
+  height : 30%;
+}
+.quest-content-header > p:nth-child(1){
+  margin-bottom: 3%;
+  font-weight: bold;
+  font-size: 1.8em;
+}
+.quest-content-header-category{
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width : 20%;
+  height : 40%;
+  border-radius: 20px;
+  font-size: 1.4em;
+  font-weight: bolder;
+}
+.quest-content-header > #movie{
+  background-color: #E5DBFE;
+  border : 4px solid #35235f;
+  color : #35235f;
+}
+.quest-content-header > #transport{
+  background-color: #cce6ff;
+  border : 4px solid #2270c5;
+  color : #2270c5;
+}
+
+/* 퀘스트 콘텐츠 detail;*/
+.quest-content-detail{
+  box-sizing: border-box;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width : 100%;
+  height : 60%;
+}
+.quest-content-detail-component{
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width : 100%;
+  height: 70%;
+}
+
+/* 퀘스트 콘텐츠 퀘스트;*/
+.quest-moviequest{
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: space-evenly;
+  background-color: #E5DBFE;
+  border : 4px solid #35235f;
+  color : #35235f;
+  width : 70%;
+  height : 100%;
+  border-radius: 10px;
+  font-size: 1.2em;
+  font-weight: bold;
+}
+.quest-moviequest-usercount{
+  display: flex;
+  justify-content: center;
+  width : 100%;
+}
+.quest-moviequest-usercount > p{
+  margin-right: 2%;
+}

--- a/gillajabi/src/styles/pages/Quest.css
+++ b/gillajabi/src/styles/pages/Quest.css
@@ -99,3 +99,7 @@
 .quest-moviequest-usercount > p{
   margin-right: 2%;
 }
+
+.quest-content > button{
+  width : 40%;
+}


### PR DESCRIPTION
### 📃 작업 내용

- Quest 페이지 추가 및 라우팅 설정
- 라우팅을 PrivateRoute로 로그인된 사용자만 접근가능하도록 설정
- 서버로부터 accessToken을 통해 퀘스트 정보에 접근하여 상태 관리
- 카테고리에 따라 id값을 부여하여 카테고리별 관리
- 사용자의 퀘스트 수락 및 수행 여부를 관리하고 퀘스트의 수락, 진행 중, 수행 완료로 구분하여 버튼을 관리
- 영화 컨텐츠에 로그인 로직을 삽입하여 사용자가 로그인 상태이며 퀘스트를 수락한 경우 퀘스트 검사를 수행

### 😎 PR 타입

- [x]  기능 추가
- [ ]  기능 수정
- [ ]  기능 삭제
- [ ]  버그 수정
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트

### 🌿 반영 브랜치

- ledraco/questSub-> develop

### ❕ 참고 사항

- 현재 퀘스트 로직은 영화 카테고리에만 적용이 된 상태이며, 이후 추가 예정
- 브랜치의 경우 ledraco/quest 브랜치의 중복 생성 이슈로 Sub로 브랜치를 생성하여 PR

### 👀 미리보기
![image](https://github.com/Team-Columbus/Gillajabi-FE/assets/98178673/2979caca-2897-4078-9558-7ce07aaed5b6)
![image](https://github.com/Team-Columbus/Gillajabi-FE/assets/98178673/c42f5c48-f1e1-4087-b760-3fa1e8e35134)
